### PR TITLE
Update container to referenceContainer

### DIFF
--- a/view/frontend/layout/hyva_checkout_components.xml
+++ b/view/frontend/layout/hyva_checkout_components.xml
@@ -4,7 +4,7 @@
 >
     <body>
         <referenceBlock name="hyva.checkout.components">
-            <container name="checkout.payment.section"
+            <referenceContainer name="checkout.payment.section"
                        htmlTag="section"
                        htmlId="payment"
             >
@@ -28,7 +28,7 @@
                         </arguments>
                     </block>
                 </block>
-            </container>
+            </referenceContainer>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
The `container` should be updated to reference to `referenceContainer`. 

This way it does not overwrite the header for example but only the `checkout.payment.methods` block under it.