### PR TITLE
Update payment methods block reference

### DIFF
--- a/view/frontend/layout/hyva_checkout_components.xml
+++ b/view/frontend/layout/hyva_checkout_components.xml
@@ -3,32 +3,17 @@
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
 >
     <body>
-        <referenceBlock name="hyva.checkout.components">
-            <container name="checkout.payment.section"
-                       htmlTag="section"
-                       htmlId="payment"
-            >
-                <block name="checkout.payment.methods"
-                       template="Hyva_Checkout::checkout/payment/method-list.phtml"
-                >
-                    <arguments>
-                        <argument name="magewire" xsi:type="object">
-                            \Hyva\Checkout\Magewire\Checkout\Payment\MethodList
-                        </argument>
-                    </arguments>
-
-                    <!-- Payment Renderer: MultiSafepay iDEAL -->
-                    <block name="checkout.payment.method.multisafepay_ideal"
-                           as="multisafepay_ideal"
-                           template="MultiSafepay_MagewireCheckout::component/payment/method/multisafepay_ideal.phtml">
-                        <arguments>
-                            <argument name="magewire" xsi:type="object">
-                                \MultiSafepay\MagewireCheckout\Payment\Method\MultiSafepayIdeal
-                            </argument>
-                        </arguments>
-                    </block>
-                </block>
-            </container>
+        <referenceBlock name="checkout.payment.methods">
+            <!-- Payment Renderer: MultiSafepay iDEAL -->
+            <block name="checkout.payment.method.multisafepay_ideal"
+                   as="multisafepay_ideal"
+                   template="MultiSafepay_MagewireCheckout::component/payment/method/multisafepay_ideal.phtml">
+                <arguments>
+                    <argument name="magewire" xsi:type="object">
+                        \MultiSafepay\MagewireCheckout\Payment\Method\MultiSafepayIdeal
+                    </argument>
+                </arguments>
+            </block>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
Hi, this is an update/follow-up after seeing PR #15, after some more testing we encountered a new issue which the other PR doesn't cover.
Just like the `checkout.payment.section` container/referenceContainer the `checkout.payment.methods` block can be accessed directly with a referenceBlock. 
Recreating this block the current way prevents other paymethods providers to render their selected paymethod.